### PR TITLE
#58 upgrade to version 5.26.0, update changelog, update releasenotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#58] Update swagger-ui to 5.26.0
 
 ## [v5.25.2-1] - 2025-06-18
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cloudogu.com/official/base:3.22.0-2 AS swaggerui
-ENV SWAGGERUI_VERSION=5.25.2 \
-    SWAGGERUI_ZIP_SHA256="65396d432106058bbedbefa6e4bee1bb760a95e3859f8b8e2b325f411167d754"
+ENV SWAGGERUI_VERSION=5.26.0 \
+    SWAGGERUI_ZIP_SHA256="b9639f47f390568ec5c29b45c4dfeef4cff8a5656d7f7537144318d465b808da"
 RUN apk update && apk add curl
 RUN curl -Lsk --fail --silent --location --retry 3 https://github.com/swagger-api/swagger-ui/archive/refs/tags/v${SWAGGERUI_VERSION}.zip -o /tmp/swagger-ui.zip
 RUN echo "${SWAGGERUI_ZIP_SHA256} */tmp/swagger-ui.zip" | sha256sum -c -
@@ -8,7 +8,7 @@ RUN unzip /tmp/swagger-ui.zip -d /tmp && mv /tmp/swagger-ui-${SWAGGERUI_VERSION}
 
 FROM registry.cloudogu.com/official/base:3.22.0-2
 LABEL NAME="official/swaggerui" \
-      VERSION="5.25.2-1" \
+      VERSION="5.26.0-0" \
       maintainer="hello@cloudogu.com"
 
 ENV SERVICE_TAGS=webapp \

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,6 +5,8 @@ Im Folgenden finden Sie die Release Notes für das Swagger UI-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/dogus/swaggerui/CHANGELOG/).
 
 ## [Unreleased]
+### Geändert
+- [#58] Das Dogu bietet nun die Swagger UI-Version 5.26.0 an.
 
 ## [v5.25.2-1] - 2025-06-18
 ### Geändert

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,6 +5,8 @@ Below you will find the release notes for the Swagger UI Dogu.
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/en/docs/dogus/swaggerui/CHANGELOG/).
 
 ## [Unreleased]
+### Changed
+- [#58] The Dogu now offers the Swagger UI version 5.26.0.
 
 ## [v5.25.2-1] - 2025-06-18
 ### Changed

--- a/dogu.json
+++ b/dogu.json
@@ -1,6 +1,6 @@
 {
   "Name": "official/swaggerui",
-  "Version": "5.25.2-1",
+  "Version": "5.26.0-0",
   "DisplayName": "Swagger UI",
   "Description": "Swagger UI displays your openAPI specification.",
   "Logo": "https://github.com/cloudogu/swagger-ui/blob/master/src/img/logo_small.png?raw=true",


### PR DESCRIPTION
### Changed
- [#58] Update swagger-ui to 5.26.0