### PR TITLE
chore: migrate Renovate regex manager config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,9 @@
   "ignorePaths": [
     "/build/**"
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": [
         "(^|/)Dockerfile$"
       ],


### PR DESCRIPTION
## Summary
- Migrates the deprecated Renovate `regexManagers` entry to `customManagers` with `customType: "regex"`
- Keeps the existing Dockerfile regex, base branch, and ignore path behavior unchanged

## Why
Renovate's Dependency Dashboard currently shows "Config Migration Needed" in #99. This PR applies the small config-shape migration so Renovate can stop flagging that dashboard item while preserving the existing matcher.

## Test plan
- `python3 -m json.tool renovate.json`

Public-data-only cleanup; no credentials or registry settings changed.
